### PR TITLE
feat(advice-generator): add advice generator

### DIFF
--- a/src/app/advice-generator/advice-generator.component.html
+++ b/src/app/advice-generator/advice-generator.component.html
@@ -1,0 +1,9 @@
+<div class="container">
+  <div class="container__main-component">Advice details</div>
+  <button
+    aria-label="next-advice-button"
+    class="container__button"
+    (click)="generateAdvice()"
+    data-testid="generate-advice"
+  ></button>
+</div>

--- a/src/app/advice-generator/advice-generator.component.html
+++ b/src/app/advice-generator/advice-generator.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="container__main-component">Advice details</div>
+  <div class="container__main-component">Advice detail</div>
   <button
     aria-label="next-advice-button"
     class="container__button"

--- a/src/app/advice-generator/advice-generator.component.html
+++ b/src/app/advice-generator/advice-generator.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="container__main-component">Advice detail</div>
+  <div class="container__main-component">Advice details</div>
   <button
     aria-label="next-advice-button"
     class="container__button"

--- a/src/app/advice-generator/advice-generator.component.scss
+++ b/src/app/advice-generator/advice-generator.component.scss
@@ -1,0 +1,34 @@
+@use '../../styles/variables';
+
+.container {
+  background-color: variables.$color-neutral-dark-grayish;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  padding: 2rem;
+  border-radius: 1rem;
+
+  &__main-component {
+    padding-bottom: 3rem;
+  }
+  &__button {
+    width: 4rem;
+    height: 4rem;
+    margin-bottom: -4rem;
+
+    background-image: url('~/src/assets/images/icon-dice.svg');
+    background-repeat: no-repeat;
+    background-position: center;
+
+    background-color: variables.$color-primary-neon-green;
+
+    border-radius: 50%;
+    border: none;
+    &:hover {
+      cursor: pointer;
+      box-shadow: 0px 0px 1.5rem 0.25rem variables.$color-primary-neon-green;
+    }
+  }
+}

--- a/src/app/advice-generator/advice-generator.component.spec.ts
+++ b/src/app/advice-generator/advice-generator.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { AdviceGeneratorComponent } from './advice-generator.component';
+
+describe('AdviceGeneratorComponent', () => {
+  let component: AdviceGeneratorComponent;
+  let fixture: ComponentFixture<AdviceGeneratorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdviceGeneratorComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdviceGeneratorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call #generateAdvice when "generate-advice" button is clicked', () => {
+    const spy = spyOn(component, 'generateAdvice');
+    const element = fixture.debugElement.query(
+      By.css('button[data-testid="generate-advice"]'),
+    );
+    const button = element.nativeElement as HTMLButtonElement;
+
+    button.click();
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/app/advice-generator/advice-generator.component.ts
+++ b/src/app/advice-generator/advice-generator.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-advice-generator',
+  templateUrl: './advice-generator.component.html',
+  styleUrls: ['./advice-generator.component.scss'],
+})
+export class AdviceGeneratorComponent {
+  public generateAdvice(): void {
+    console.log('generate new advice');
+  }
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,1 @@
-<h1>Advice generator 🚀</h1>
+<app-advice-generator></app-advice-generator>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,10 +1,13 @@
 import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { AdviceGeneratorComponent } from './advice-generator/advice-generator.component';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [AppComponent],
+      imports: [AdviceGeneratorComponent],
     }).compileComponents();
   });
 
@@ -12,5 +15,15 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
+  });
+
+  it('should render AdviceGeneratorComponent element', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    const element = fixture.debugElement.query(
+      By.directive(AdviceGeneratorComponent),
+    );
+    expect(element).toBeTruthy();
   });
 });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { AdviceGeneratorComponent } from './advice-generator/advice-generator.component';
 
 import { AppComponent } from './app.component';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule],
+  imports: [AdviceGeneratorComponent, BrowserModule],
   providers: [],
   bootstrap: [AppComponent],
 })


### PR DESCRIPTION
## What has been done

Add and integrate the `advice-generator` component.
Implement only the skeleton design and add the dummy  method `generateAdvice`. 

## How to review

- All checks must pass successfully.
- Run `npm run start` and go to http://localhost:4200/. Check the implementation match the skeleton design.

![image](https://user-images.githubusercontent.com/79798431/235477614-ef50cd68-c824-4151-9b7b-3d442cf6132a.png)
