### PR TITLE
Feat/implement advice generator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,8 @@
         "@angular-eslint/relative-url-prefix": "error",
         "@angular-eslint/sort-ngmodule-metadata-arrays": "error",
         "@angular-eslint/use-component-selector": "error",
-        "@angular-eslint/use-component-view-encapsulation": "error"
+        "@angular-eslint/use-component-view-encapsulation": "error",
+        "prettier/prettier": ["error", { "endOfLine": "auto" }]
       }
     },
     {
@@ -64,7 +65,10 @@
       "excludedFiles": ["*inline-template-*.component.html"],
       "extends": ["plugin:prettier/recommended"],
       "rules": {
-        "prettier/prettier": ["error", { "parser": "angular" }]
+        "prettier/prettier": [
+          "error",
+          { "parser": "angular", "endOfLine": "auto" }
+        ]
       }
     }
   ]

--- a/src/app/advice-generator/advice-generator.component.html
+++ b/src/app/advice-generator/advice-generator.component.html
@@ -1,5 +1,12 @@
 <div class="container">
-  <div class="container__main-component">Advice details</div>
+  <div
+    class="container__main-component advice"
+    *ngIf="currentAdvice$ | async as advice"
+  >
+    <p class="advice__id">Advice # {{ advice.id }}</p>
+    <p class="advice__text">“{{ advice.advice }}”</p>
+  </div>
+  <div class="container__divider" aria-label="divisory-line-image"></div>
   <button
     aria-label="next-advice-button"
     class="container__button"

--- a/src/app/advice-generator/advice-generator.component.scss
+++ b/src/app/advice-generator/advice-generator.component.scss
@@ -1,22 +1,37 @@
 @use '../../styles/variables';
 
+$button-size: 4rem;
+
 .container {
   background-color: variables.$color-neutral-dark-grayish;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  max-width: 600px;
+  min-width: 300px;
 
-  padding: 2rem;
+  margin-left: 2rem;
+  margin-right: 2rem;
+
+  padding: calc($button-size/2);
   border-radius: 1rem;
 
-  &__main-component {
+  &__divider {
+    background-image: url(../../assets/images/pattern-divider-desktop.svg);
+    background-repeat: no-repeat;
+    background-position: center;
+    width: 444px;
+    height: 16px;
+
+    padding-top: 3rem;
     padding-bottom: 3rem;
   }
+
   &__button {
-    width: 4rem;
-    height: 4rem;
-    margin-bottom: -4rem;
+    width: $button-size;
+    height: $button-size;
+    margin-bottom: -$button-size;
 
     background-image: url('~/src/assets/images/icon-dice.svg');
     background-repeat: no-repeat;
@@ -30,5 +45,30 @@
       cursor: pointer;
       box-shadow: 0px 0px 1.5rem 0.25rem variables.$color-primary-neon-green;
     }
+  }
+}
+
+.advice {
+  display: flex;
+  flex-direction: column;
+  place-items: center;
+  gap: 1rem;
+  &__id {
+    font-size: 0.825rem;
+    color: variables.$color-primary-neon-green;
+    text-transform: uppercase;
+    letter-spacing: 3px;
+  }
+  &__text {
+    font-size: 2rem;
+    color: variables.$color-primary-light-cyan;
+    text-align: center;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .container__divider {
+    background-image: url(../../assets/images/pattern-divider-mobile.svg);
+    width: 295px;
   }
 }

--- a/src/app/advice-generator/advice-generator.component.ts
+++ b/src/app/advice-generator/advice-generator.component.ts
@@ -3,6 +3,7 @@ import { AdviceHandlerService } from './data-access/advice-handler.service';
 import { Subject, takeUntil } from 'rxjs';
 import { HttpClientModule } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
+
 @Component({
   standalone: true,
   selector: 'app-advice-generator',

--- a/src/app/advice-generator/advice-generator.component.ts
+++ b/src/app/advice-generator/advice-generator.component.ts
@@ -1,13 +1,34 @@
-import { Component } from '@angular/core';
-
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { AdviceHandlerService } from './data-access/advice-handler.service';
+import { Subject, takeUntil } from 'rxjs';
+import { HttpClientModule } from '@angular/common/http';
+import { CommonModule } from '@angular/common';
 @Component({
   standalone: true,
   selector: 'app-advice-generator',
+  imports: [HttpClientModule, CommonModule],
   templateUrl: './advice-generator.component.html',
   styleUrls: ['./advice-generator.component.scss'],
 })
-export class AdviceGeneratorComponent {
+export class AdviceGeneratorComponent implements OnDestroy, OnInit {
+  private destroy = new Subject<void>();
+  public currentAdvice$ = this.adviceHandlerService.advice$;
+
+  constructor(private adviceHandlerService: AdviceHandlerService) {}
+
   public generateAdvice(): void {
-    console.log('generate new advice');
+    this.adviceHandlerService
+      .getNewAdvice()
+      .pipe(takeUntil(this.destroy))
+      .subscribe();
+  }
+
+  ngOnInit(): void {
+    this.generateAdvice();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy.next();
+    this.destroy.complete();
   }
 }

--- a/src/app/advice-generator/data-access/advice-handler.service.spec.ts
+++ b/src/app/advice-generator/data-access/advice-handler.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AdviceHandlerService } from './advice-handler.service';
+
+describe('AdviceHandlerService', () => {
+  let service: AdviceHandlerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AdviceHandlerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/advice-generator/data-access/advice-handler.service.spec.ts
+++ b/src/app/advice-generator/data-access/advice-handler.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { AdviceHandlerService } from './advice-handler.service';
 
@@ -6,7 +7,9 @@ describe('AdviceHandlerService', () => {
   let service: AdviceHandlerService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(AdviceHandlerService);
   });
 

--- a/src/app/advice-generator/data-access/advice-handler.service.ts
+++ b/src/app/advice-generator/data-access/advice-handler.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, tap, map } from 'rxjs';
+import { Slip } from '../models/slip';
+import { HttpClient } from '@angular/common/http';
+import { Advice } from '../models/advice';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AdviceHandlerService {
+  private advice = new BehaviorSubject<Advice>({ advice: '', id: 0 });
+  public advice$ = this.advice.asObservable();
+  private apiUrl = 'https://api.adviceslip.com/advice?t=';
+
+  constructor(private http: HttpClient) {}
+
+  public getNewAdvice() {
+    return this.http.get<Slip>(this.apiUrl + Math.random()).pipe(
+      map((response) => response.slip),
+      tap((response) => {
+        this.advice.next(response);
+      }),
+    );
+  }
+}

--- a/src/app/advice-generator/models/advice.ts
+++ b/src/app/advice-generator/models/advice.ts
@@ -1,0 +1,4 @@
+export interface Advice {
+  advice: string;
+  id: number;
+}

--- a/src/app/advice-generator/models/slip.ts
+++ b/src/app/advice-generator/models/slip.ts
@@ -1,0 +1,6 @@
+export interface Slip {
+  slip: {
+    advice: string;
+    id: number;
+  };
+}


### PR DESCRIPTION
## What has been done
Finish the implementation of the `advice-generator` component. Styles and media queries upgraded.
Add models to handle the HTTP response.
Add the `advice-handler` service to handle the calls to the external API.

## How to review
Run `npm run start` and go to [http://localhost:4200/](http://localhost:4200/). Then click the button and check that the advice changes. Also check that each time a new HTTP call is made in the Network section when inspecting the page. 
